### PR TITLE
fix: handle navigationwindows as left and right properties

### DIFF
--- a/ios/Classes/DkNappDrawerDrawer.m
+++ b/ios/Classes/DkNappDrawerDrawer.m
@@ -106,13 +106,24 @@ UINavigationController *NavigationControllerForViewProxy(TiUINavigationWindowPro
 
     if (leftWindow != nil) {
 
+      BOOL leftIsNav = NO;
+      if ([[[leftWindow class] description] isEqualToString:@"TiUINavigationWindowProxy"]) {
+          leftIsNav = YES;
+      }
+
+      TiViewController *leftController = leftIsNav ? NavigationControllerForViewProxy(leftWindow) : ControllerForViewProxy(leftWindow);
+
       //both left and right
       if (rightWindow != nil) {
 
-        TiViewController *leftController = ControllerForViewProxy(leftWindow);
-        TiViewController *rightController = ControllerForViewProxy(rightWindow);
+        BOOL rightIsNav = NO;
+        if ([[[rightWindow class] description] isEqualToString:@"TiUINavigationWindowProxy"]) {
+            rightIsNav = YES;
+        }
 
-          TiUINavigationWindowProxy *centerProxy = [self.proxy valueForUndefinedKey:@"centerWindow"];
+        TiViewController *rightController = rightIsNav ? NavigationControllerForViewProxy(rightWindow) : ControllerForViewProxy(rightWindow);
+
+        TiUINavigationWindowProxy *centerProxy = [self.proxy valueForUndefinedKey:@"centerWindow"];
 
         TiThreadPerformOnMainThread(^{
           [centerProxy windowWillOpen];
@@ -126,9 +137,7 @@ UINavigationController *NavigationControllerForViewProxy(TiUINavigationWindowPro
         //left only
       } else {
 
-        TiViewController *leftController = ControllerForViewProxy(leftWindow);
-
-          TiUINavigationWindowProxy *centerProxy = [self.proxy valueForUndefinedKey:@"centerWindow"];
+        TiUINavigationWindowProxy *centerProxy = [self.proxy valueForUndefinedKey:@"centerWindow"];
 
         TiThreadPerformOnMainThread(^{
           [centerProxy windowWillOpen];
@@ -142,9 +151,14 @@ UINavigationController *NavigationControllerForViewProxy(TiUINavigationWindowPro
       //right only
     } else if (rightWindow != nil) {
 
-      TiViewController *rightController = ControllerForViewProxy(rightWindow);
+      BOOL rightIsNav = NO;
+      if ([[[rightWindow class] description] isEqualToString:@"TiUINavigationWindowProxy"]) {
+          rightIsNav = YES;
+      }
 
-        TiUINavigationWindowProxy *centerProxy = [self.proxy valueForUndefinedKey:@"centerWindow"];
+      TiViewController *rightController = rightIsNav ? NavigationControllerForViewProxy(rightWindow) : ControllerForViewProxy(rightWindow);
+
+      TiUINavigationWindowProxy *centerProxy = [self.proxy valueForUndefinedKey:@"centerWindow"];
 
       TiThreadPerformOnMainThread(^{
         [centerProxy windowWillOpen];


### PR DESCRIPTION
This PR fixes usage of the NavigationWindows in the leftWindow/rightWindow properties which appears to have broke since SDK 10 due to changes in the SDK. Error and test code below

```
[INFO]  *** Terminating app due to uncaught exception 'UIViewControllerHierarchyInconsistency', reason: 'child view controller:<UINavigationController: 0x7fb88902e400> should have parent view controller:<TiViewController: 0x7fb88670be90> but actual parent is:<TiRootViewController: 0x7fb886856400>'

```

```js
const NappDrawerModule = require('dk.napp.drawer');

const mainWindow = Ti.UI.createWindow({ title: "Main View", backgroundColor: 'pink' });
const detailWindow = Ti.UI.createWindow({ title: "Detail View" });
detailWindow.add(Ti.UI.createLabel({ text: "Hello World!" }));

const win = Ti.UI.iOS.createSplitWindow({
	detailView: Ti.UI.createNavigationWindow({ window: detailWindow }),
	masterView: Ti.UI.createNavigationWindow({ window: mainWindow }),
	backgroundColor: "white",
	showMasterInPortrait: true,
});

const drawer = NappDrawerModule.createDrawer({
	leftWindow: Ti.UI.createWindow(),
	centerWindow: win,
	rightWindow: Ti.UI.createNavigationWindow({window: Ti.UI.createWindow(), backgroundColor: "red"}),

});

drawer.open();
```